### PR TITLE
Sort resolved dependencies in install-order for callers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ all: $(LIBRARY)
 
 .PHONY: check docs $(TEST_RUNNER)
 
-check: examples $(TEST_RUNNER)
+check: $(TEST_RUNNER) examples
 	$(TEST_RUNNER)
 
 clean:

--- a/examples/library_folders/main.c
+++ b/examples/library_folders/main.c
@@ -56,25 +56,34 @@ int main (int argc, const char **argv)
   ArbiterResolver *resolver = ArbiterCreateResolver(behaviors, dependencyList, NULL);
   ArbiterFree(dependencyList);
 
-  ArbiterResolvedDependencyList *resolvedList = ArbiterResolverCreateResolvedDependencyList(resolver, &error);
+  ArbiterResolvedDependencyGraph *resolvedGraph = ArbiterResolverCreateResolvedDependencyGraph(resolver, &error);
   ArbiterFree(resolver);
-  if (!resolvedList) {
+  if (!resolvedGraph) {
     die(error);
   }
 
-  size_t count = ArbiterResolvedDependencyListCount(resolvedList);
+  size_t depth = ArbiterResolvedDependencyGraphDepth(resolvedGraph);
 
-  const ArbiterResolvedDependency *resolved[count];
-  ArbiterResolvedDependencyListGetAll(resolvedList, resolved); 
+  for (size_t depthIndex = 0; depthIndex < depth; depthIndex++) {
+    size_t count = ArbiterResolvedDependencyGraphCountAtDepth(resolvedGraph, depthIndex);
 
-  for (size_t i = 0; i < count; i++) {
-    const ArbiterProjectIdentifier *project = ArbiterResolvedDependencyProject(resolved[i]);
-    const ArbiterSelectedVersion *version = ArbiterResolvedDependencyVersion(resolved[i]);
+    const ArbiterResolvedDependency *resolved[count];
+    ArbiterResolvedDependencyGraphGetAllAtDepth(resolvedGraph, depthIndex, resolved); 
 
-    printf("%s @ %s\n", ArbiterProjectIdentifierValue(project), ArbiterSelectedVersionMetadata(version));
+    printf("{ ");
+    for (size_t i = 0; i < count; i++) {
+      const ArbiterProjectIdentifier *project = ArbiterResolvedDependencyProject(resolved[i]);
+      const ArbiterSelectedVersion *version = ArbiterResolvedDependencyVersion(resolved[i]);
+      printf("%s @ %s", ArbiterProjectIdentifierValue(project), ArbiterSelectedVersionMetadata(version));
+      
+      if (i + 1 < count) {
+        printf(", ");
+      }
+    }
+
+    printf(" }\n");
   }
 
-  ArbiterFree(resolvedList);
-
+  ArbiterFree(resolvedGraph);
   return EXIT_SUCCESS;
 }

--- a/include/arbiter/Resolver.h
+++ b/include/arbiter/Resolver.h
@@ -12,7 +12,7 @@ extern "C" {
 // forward declarations
 struct ArbiterDependencyList;
 struct ArbiterProjectIdentifier;
-struct ArbiterResolvedDependencyList;
+struct ArbiterResolvedDependencyGraph;
 struct ArbiterSelectedVersion;
 struct ArbiterSelectedVersionList;
 
@@ -69,12 +69,12 @@ const void *ArbiterResolverContext (const ArbiterResolver *resolver);
 /**
  * Attempts to resolve all dependencies.
  *
- * Returns the list of resolved dependencies, or NULL if an error occurred. The
- * caller is responsible for freeing the returned list. If NULL is returned and
+ * Returns the graph of resolved dependencies, or NULL if an error occurred. The
+ * caller is responsible for freeing the returned graph. If NULL is returned and
  * `error` is not NULL, it may be set to a string describing the error, which
  * the caller is responsible for freeing.
  */
-struct ArbiterResolvedDependencyList *ArbiterResolverCreateResolvedDependencyList (ArbiterResolver *resolver, char **error);
+struct ArbiterResolvedDependencyGraph *ArbiterResolverCreateResolvedDependencyGraph (ArbiterResolver *resolver, char **error);
 
 #ifdef __cplusplus
 }

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -213,6 +213,17 @@ size_t ArbiterResolvedDependencyGraph::countAtDepth (size_t depthIndex) const
   return _depths.at(depthIndex).size();
 }
 
+bool ArbiterResolvedDependencyGraph::contains (const ArbiterResolvedDependency &node) const
+{
+  for (const DepthSet &depth : _depths) {
+    if (depth.find(node) != depth.end()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 std::unique_ptr<Arbiter::Base> ArbiterResolvedDependencyGraph::clone () const
 {
   return std::make_unique<ArbiterResolvedDependencyGraph>(*this);

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -59,31 +59,34 @@ const ArbiterSelectedVersion *ArbiterResolvedDependencyVersion (const ArbiterRes
   return &dependency->_version;
 }
 
-ArbiterResolvedDependencyList *ArbiterCreateResolvedDependencyList (const ArbiterResolvedDependency * const *dependencies, size_t count)
+size_t ArbiterResolvedDependencyGraphCount (const ArbiterResolvedDependencyGraph *graph)
 {
-  std::vector<ArbiterResolvedDependency> vec;
-  vec.reserve(count);
+  return graph->count();
+}
 
-  for (size_t i = 0; i < count; i++) {
-    vec.emplace_back(*dependencies[i]);
+void ArbiterResolvedDependencyGraphGetAll (const ArbiterResolvedDependencyGraph *graph, const ArbiterResolvedDependency **buffer)
+{
+  for (const auto &depth : graph->_depths) {
+    for (const auto &dependency : depth) {
+      *(buffer++) = &dependency;
+    }
   }
-
-  return new ArbiterResolvedDependencyList(std::move(vec));
 }
 
-size_t ArbiterResolvedDependencyListCount (const ArbiterResolvedDependencyList *dependencyList)
+size_t ArbiterResolvedDependencyGraphDepth (const ArbiterResolvedDependencyGraph *graph)
 {
-  return dependencyList->_dependencies.size();
+  return graph->depth();
 }
 
-const ArbiterResolvedDependency *ArbiterResolvedDependencyListGetIndex (const ArbiterResolvedDependencyList *dependencyList, size_t index)
+size_t ArbiterResolvedDependencyGraphCountAtDepth (const ArbiterResolvedDependencyGraph *graph, size_t depthIndex)
 {
-  return &dependencyList->_dependencies.at(index);
+  return graph->countAtDepth(depthIndex);
 }
 
-void ArbiterResolvedDependencyListGetAll (const ArbiterResolvedDependencyList *dependencyList, const ArbiterResolvedDependency **buffer)
+void ArbiterResolvedDependencyGraphGetAllAtDepth (const ArbiterResolvedDependencyGraph *graph, size_t depthIndex, const ArbiterResolvedDependency **buffer)
 {
-  for (const auto &dependency : dependencyList->_dependencies) {
+  const auto &depth = graph->_depths.at(depthIndex);
+  for (const auto &dependency : depth) {
     *(buffer++) = &dependency;
   }
 }
@@ -190,30 +193,52 @@ bool ArbiterResolvedDependency::operator== (const Arbiter::Base &other) const
   return _project == ptr->_project && _version == ptr->_version;
 }
 
-std::unique_ptr<Arbiter::Base> ArbiterResolvedDependencyList::clone () const
+size_t ArbiterResolvedDependencyGraph::count () const
 {
-  return std::make_unique<ArbiterResolvedDependencyList>(*this);
+  size_t accum = 0;
+  for (size_t i = 0; i < depth(); ++i) {
+    accum += countAtDepth(i);
+  }
+
+  return accum;
 }
 
-std::ostream &ArbiterResolvedDependencyList::describe (std::ostream &os) const
+size_t ArbiterResolvedDependencyGraph::depth () const noexcept
 {
-  os << "Resolved dependency list:";
+  return _depths.size();
+}
 
-  for (const auto &dep : _dependencies) {
-    os << "\n" << dep;
+size_t ArbiterResolvedDependencyGraph::countAtDepth (size_t depthIndex) const
+{
+  return _depths.at(depthIndex).size();
+}
+
+std::unique_ptr<Arbiter::Base> ArbiterResolvedDependencyGraph::clone () const
+{
+  return std::make_unique<ArbiterResolvedDependencyGraph>(*this);
+}
+
+std::ostream &ArbiterResolvedDependencyGraph::describe (std::ostream &os) const
+{
+  os << "Resolved dependency graph:";
+
+  for (const auto &depth : _depths) {
+    for (const auto &dependency : depth) {
+      os << "\n" << dependency;
+    }
   }
 
   return os;
 }
 
-bool ArbiterResolvedDependencyList::operator== (const Arbiter::Base &other) const
+bool ArbiterResolvedDependencyGraph::operator== (const Arbiter::Base &other) const
 {
-  auto ptr = dynamic_cast<const ArbiterResolvedDependencyList *>(&other);
+  auto ptr = dynamic_cast<const ArbiterResolvedDependencyGraph *>(&other);
   if (!ptr) {
     return false;
   }
 
-  return _dependencies == ptr->_dependencies;
+  return _depths == ptr->_depths;
 }
 
 size_t std::hash<ArbiterProjectIdentifier>::operator() (const ArbiterProjectIdentifier &project) const

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -114,7 +114,10 @@ struct ArbiterResolvedDependency final : public Arbiter::Base
 struct ArbiterResolvedDependencyGraph final : public Arbiter::Base
 {
   public:
-    std::vector<std::unordered_set<ArbiterResolvedDependency>> _depths;
+    // TODO: Should this be ordered?
+    using DepthSet = std::unordered_set<ArbiterResolvedDependency>;
+
+    std::vector<DepthSet> _depths;
 
     ArbiterResolvedDependencyGraph () = default;
 

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <memory>
 #include <ostream>
+#include <unordered_set>
 #include <vector>
 
 struct ArbiterRequirement;
@@ -110,22 +111,17 @@ struct ArbiterResolvedDependency final : public Arbiter::Base
     bool operator== (const Arbiter::Base &other) const override;
 };
 
-struct ArbiterResolvedDependencyList final : public Arbiter::Base
+struct ArbiterResolvedDependencyGraph final : public Arbiter::Base
 {
   public:
-    std::vector<ArbiterResolvedDependency> _dependencies;
+    std::vector<std::unordered_set<ArbiterResolvedDependency>> _depths;
 
-    ArbiterResolvedDependencyList () = default;
+    ArbiterResolvedDependencyGraph () = default;
 
-    explicit ArbiterResolvedDependencyList (std::vector<ArbiterResolvedDependency> dependencies)
-      : _dependencies(std::move(dependencies))
-    {}
+    size_t count () const;
 
-    ArbiterResolvedDependencyList (const ArbiterResolvedDependencyList &) = default;
-    ArbiterResolvedDependencyList &operator= (const ArbiterResolvedDependencyList &) = default;
-
-    ArbiterResolvedDependencyList (ArbiterResolvedDependencyList &&) = default;
-    ArbiterResolvedDependencyList &operator= (ArbiterResolvedDependencyList &&) = default;
+    size_t depth () const noexcept;
+    size_t countAtDepth (size_t depthIndex) const;
 
     std::unique_ptr<Arbiter::Base> clone () const override;
     std::ostream &describe (std::ostream &os) const override;

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -126,6 +126,8 @@ struct ArbiterResolvedDependencyGraph final : public Arbiter::Base
     size_t depth () const noexcept;
     size_t countAtDepth (size_t depthIndex) const;
 
+    bool contains (const ArbiterResolvedDependency &node) const;
+
     std::unique_ptr<Arbiter::Base> clone () const override;
     std::ostream &describe (std::ostream &os) const override;
     bool operator== (const Arbiter::Base &other) const override;

--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -71,6 +71,10 @@ class DependencyGraph final
     ArbiterResolvedDependencyGraph resolvedGraph () const
     {
       ArbiterResolvedDependencyGraph resolved;
+      if (_nodeMap.empty()) {
+        return resolved;
+      }
+
       size_t resolvedCount = 0;
 
       // Maps from dependencies to their dependents.

--- a/src/Resolver.h
+++ b/src/Resolver.h
@@ -53,7 +53,7 @@ struct ArbiterResolver final : public Arbiter::Base
     /**
      * Attempts to resolve all dependencies.
      */
-    ArbiterResolvedDependencyList resolve () noexcept(false);
+    ArbiterResolvedDependencyGraph resolve () noexcept(false);
 
     std::unique_ptr<Arbiter::Base> clone () const override;
     std::ostream &describe (std::ostream &os) const override;


### PR DESCRIPTION
This will sort the graph so that callers know in what order to build things, and which builds can be parallelized.