### PR TITLE
Add support for custom version requirements with a predicate

### DIFF
--- a/include/arbiter/Requirement.h
+++ b/include/arbiter/Requirement.h
@@ -9,6 +9,7 @@ extern "C" {
 
 // forward declarations
 struct ArbiterSemanticVersion;
+struct ArbiterSelectedVersion;
 
 /**
  * Represents a requirement for a specific version or set of versions.
@@ -101,9 +102,9 @@ ArbiterRequirement *ArbiterCreateRequirementCompatibleWith (const struct Arbiter
 ArbiterRequirement *ArbiterCreateRequirementExactly (const struct ArbiterSemanticVersion *version);
 
 /**
- * Determines whether the given requirement is satisfied by the given version.
+ * Determines how well the given requirement is satisfied by the given version.
  */
-bool ArbiterRequirementSatisfiedBy (const ArbiterRequirement *requirement, const struct ArbiterSemanticVersion *version);
+ArbiterRequirementSuitability ArbiterRequirementSatisfiedBy (const ArbiterRequirement *requirement, const struct ArbiterSelectedVersion *version);
 
 #ifdef __cplusplus
 }

--- a/include/arbiter/Requirement.h
+++ b/include/arbiter/Requirement.h
@@ -11,6 +11,11 @@ extern "C" {
 struct ArbiterSemanticVersion;
 
 /**
+ * Represents a requirement for a specific version or set of versions.
+ */
+typedef struct ArbiterRequirement ArbiterRequirement;
+
+/**
  * How strict to be in matching compatible versions.
  */
 typedef enum
@@ -32,9 +37,33 @@ typedef enum
 } ArbiterRequirementStrictness;
 
 /**
- * Represents a requirement for a specific version or set of versions.
+ * How suitable a specific version is for a requirement.
  */
-typedef struct ArbiterRequirement ArbiterRequirement;
+typedef enum
+{
+  /**
+   * The version is unsuitable for (does not satisfy) the requirement.
+   */
+  ArbiterRequirementSuitabilityUnsuitable,
+
+  /**
+   * The version is suitable for (satisfies) the requirement.
+   */
+  ArbiterRequirementSuitabilitySuitable,
+  
+  /**
+   * The version should be considered the best possible choice for satisfying
+   * the requirement.
+   *
+   * This result is unique in that it _overrides other requirements_, which is
+   * sometimes desirable (e.g., pinning to a specific named branch or tag
+   * instead of a semantic version).
+   *
+   * If this result is returned multiple times for different versions, it is
+   * unspecified which version will be selected.
+   */
+  ArbiterRequirementSuitabilityBestPossibleChoice,
+} ArbiterRequirementSuitability;
 
 /**
  * Creates a requirement which will match any version.

--- a/include/arbiter/Requirement.h
+++ b/include/arbiter/Requirement.h
@@ -102,6 +102,17 @@ ArbiterRequirement *ArbiterCreateRequirementCompatibleWith (const struct Arbiter
 ArbiterRequirement *ArbiterCreateRequirementExactly (const struct ArbiterSemanticVersion *version);
 
 /**
+ * Creates a compound requirement that evaluates each of a list of requirements.
+ * All of the requirements must be satisfied for the compound requirement to be
+ * satisfied.
+ *
+ * The objects in the C array can be safely freed after calling this function.
+ *
+ * The returned requirement must be freed with ArbiterFree().
+ */
+ArbiterRequirement *ArbiterCreateRequirementCompound (const ArbiterRequirement * const *requirements, size_t count);
+
+/**
  * Determines how well the given requirement is satisfied by the given version.
  */
 ArbiterRequirementSuitability ArbiterRequirementSatisfiedBy (const ArbiterRequirement *requirement, const struct ArbiterSelectedVersion *version);

--- a/include/arbiter/Requirement.h
+++ b/include/arbiter/Requirement.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stddef.h>
 
 // forward declarations
 struct ArbiterSemanticVersion;
@@ -67,6 +68,12 @@ typedef enum
 } ArbiterRequirementSuitability;
 
 /**
+ * A predicate used to determine whether the given version suitably satisfies
+ * the requirement.
+ */
+typedef ArbiterRequirementSuitability (*ArbiterRequirementPredicate)(const struct ArbiterSelectedVersion *version, const void *context);
+
+/**
  * Creates a requirement which will match any version.
  *
  * The returned requirement must be freed with ArbiterFree().
@@ -100,6 +107,15 @@ ArbiterRequirement *ArbiterCreateRequirementCompatibleWith (const struct Arbiter
  * The returned requirement must be freed with ArbiterFree().
  */
 ArbiterRequirement *ArbiterCreateRequirementExactly (const struct ArbiterSemanticVersion *version);
+
+/**
+ * Creates a requirement which will evaluate a custom predicate whenever
+ * a specific version is checked against it.
+ *
+ * The returned requirement must be freed with ArbiterFree().
+ */
+// TODO: `context` may need memory management
+ArbiterRequirement *ArbiterCreateRequirementCustom (ArbiterRequirementPredicate predicate, const void *context);
 
 /**
  * Creates a compound requirement that evaluates each of a list of requirements.

--- a/src/Requirement.cpp
+++ b/src/Requirement.cpp
@@ -30,6 +30,15 @@ bool ArbiterRequirementSatisfiedBy (const ArbiterRequirement *requirement, const
   return requirement->satisfiedBy(*version);
 }
 
+ArbiterRequirementSuitability ArbiterRequirement::satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const
+{
+  if (satisfiedBy(selectedVersion._semanticVersion)) {
+    return ArbiterRequirementSuitabilitySuitable;
+  } else {
+    return ArbiterRequirementSuitabilityUnsuitable;
+  }
+}
+
 std::unique_ptr<ArbiterRequirement> ArbiterRequirement::cloneRequirement () const
 {
   return std::unique_ptr<ArbiterRequirement>(dynamic_cast<ArbiterRequirement *>(clone().release()));

--- a/src/Requirement.cpp
+++ b/src/Requirement.cpp
@@ -399,24 +399,26 @@ size_t Custom::hash () const noexcept
 
 ArbiterRequirementSuitability Compound::satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const
 {
-  ArbiterRequirementSuitability result = ArbiterRequirementSuitabilitySuitable;
+  bool suitable = true;
 
   for (const auto &requirement : _requirements) {
     ArbiterRequirementSuitability suitability = requirement->satisfiedBy(selectedVersion);
+
     switch (suitability) {
       case ArbiterRequirementSuitabilityUnsuitable:
-        return ArbiterRequirementSuitabilityUnsuitable;
+        suitable = false;
+        break;
 
       case ArbiterRequirementSuitabilityBestPossibleChoice:
-        result = ArbiterRequirementSuitabilityBestPossibleChoice;
-        break;
+        // Takes precedence over unsuitable versions.
+        return ArbiterRequirementSuitabilityBestPossibleChoice;
 
       case ArbiterRequirementSuitabilitySuitable:
         break;
     }
   }
 
-  return result;
+  return (suitable ? ArbiterRequirementSuitabilitySuitable : ArbiterRequirementSuitabilityUnsuitable);
 }
 
 std::ostream &Compound::describe (std::ostream &os) const

--- a/src/Requirement.cpp
+++ b/src/Requirement.cpp
@@ -25,6 +25,11 @@ ArbiterRequirement *ArbiterCreateRequirementExactly (const ArbiterSemanticVersio
   return new Arbiter::Requirement::Exactly(*version);
 }
 
+ArbiterRequirement *ArbiterCreateRequirementCustom (ArbiterRequirementPredicate predicate, const void *context)
+{
+  return new Arbiter::Requirement::Custom(std::move(predicate), context);
+}
+
 ArbiterRequirement *ArbiterCreateRequirementCompound (const ArbiterRequirement * const *requirements, size_t count)
 {
   std::vector<std::shared_ptr<ArbiterRequirement>> vec;
@@ -180,6 +185,22 @@ struct Intersect<Exactly, Exactly> final
   }
 };
 
+template<typename Other>
+struct Intersect<Custom, Other> final
+{
+  using Result = std::unique_ptr<ArbiterRequirement>;
+
+  Result operator() (const Custom &custom, const Other &other) const
+  {
+    std::vector<std::shared_ptr<ArbiterRequirement>> requirements = {
+      std::shared_ptr<ArbiterRequirement>(other.cloneRequirement()),
+      std::shared_ptr<ArbiterRequirement>(custom.cloneRequirement())
+    };
+
+    return std::make_unique<Compound>(std::move(requirements));
+  }
+};
+
 template<>
 struct Intersect<Compound, Compound> final
 {
@@ -210,6 +231,7 @@ const std::type_info &any = typeid(Any);
 const std::type_info &atLeast = typeid(AtLeast);
 const std::type_info &compatibleWith = typeid(CompatibleWith);
 const std::type_info &exactly = typeid(Exactly);
+const std::type_info &custom = typeid(Custom);
 const std::type_info &compound = typeid(Compound);
 
 template<typename Left>
@@ -223,6 +245,8 @@ std::unique_ptr<ArbiterRequirement> intersectRight(const Left &lhs, const Arbite
     return Intersect<Left, CompatibleWith>()(lhs, dynamic_cast<const CompatibleWith &>(rhs));
   } else if (typeid(rhs) == exactly) {
     return Intersect<Left, Exactly>()(lhs, dynamic_cast<const Exactly &>(rhs));
+  } else if (typeid(rhs) == custom) {
+    return Intersect<Left, Custom>()(lhs, dynamic_cast<const Custom &>(rhs));
   } else if (typeid(rhs) == compound) {
     return Intersect<Left, Compound>()(lhs, dynamic_cast<const Compound &>(rhs));
   } else {
@@ -354,6 +378,25 @@ std::ostream &Exactly::describe (std::ostream &os) const
   return os << "==" << _version;
 }
 
+ArbiterRequirementSuitability Custom::satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const
+{
+  return _predicate(&selectedVersion, _context);
+}
+
+bool Custom::operator== (const Arbiter::Base &other) const
+{
+  if (auto *ptr = dynamic_cast<const Custom *>(&other)) {
+    return _predicate == ptr->_predicate && _context == ptr->_context;
+  } else {
+    return false;
+  }
+}
+
+size_t Custom::hash () const noexcept
+{
+  return hashOf(_predicate) ^ hashOf(_context);
+}
+
 ArbiterRequirementSuitability Compound::satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const
 {
   ArbiterRequirementSuitability result = ArbiterRequirementSuitabilitySuitable;
@@ -429,6 +472,11 @@ std::unique_ptr<ArbiterRequirement> CompatibleWith::intersect (const ArbiterRequ
 std::unique_ptr<ArbiterRequirement> Exactly::intersect (const ArbiterRequirement &rhs) const
 {
   return intersectRight<Exactly>(*this, rhs);
+}
+
+std::unique_ptr<ArbiterRequirement> Custom::intersect (const ArbiterRequirement &rhs) const
+{
+  return intersectRight<Custom>(*this, rhs);
 }
 
 std::unique_ptr<ArbiterRequirement> Compound::intersect (const ArbiterRequirement &rhs) const

--- a/src/Requirement.h
+++ b/src/Requirement.h
@@ -17,9 +17,22 @@ struct ArbiterRequirement : public Arbiter::Base
   public:
     /**
      * Returns whether this requirement would be satisfied by using the given
-     * version.
+     * semantic version.
+     *
+     * Some requirements may only be satisfied by certain _selected_ versions,
+     * and so may fail this check regardless of the semantic version provided
+     * here.
      */
     virtual bool satisfiedBy (const ArbiterSemanticVersion &version) const noexcept = 0;
+
+    /**
+     * Returns whether this requirement would be satisfied by using the given
+     * selected version.
+     *
+     * The default behavior is that any selected version whose semantic version
+     * passes satisfiedBy() results in ArbiterRequirementSuitabilitySuitable.
+     */
+    virtual ArbiterRequirementSuitability satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const;
 
     /**
      * Attempts to create a requirement which expresses the intersection of this
@@ -50,6 +63,11 @@ class Any final : public ArbiterRequirement
     bool satisfiedBy (const ArbiterSemanticVersion &) const noexcept override
     {
       return true;
+    }
+
+    ArbiterRequirementSuitability satisfiedBy (const ArbiterSelectedVersion &) const override
+    {
+      return ArbiterRequirementSuitabilitySuitable;
     }
 
     bool operator== (const Arbiter::Base &other) const override

--- a/src/Requirement.h
+++ b/src/Requirement.h
@@ -9,6 +9,7 @@
 #include "Types.h"
 #include "Version.h"
 
+#include <cassert>
 #include <memory>
 #include <ostream>
 
@@ -158,6 +159,36 @@ class Exactly final : public ArbiterRequirement
     bool operator== (const Arbiter::Base &other) const override;
     std::unique_ptr<ArbiterRequirement> intersect (const ArbiterRequirement &rhs) const override;
     size_t hash () const noexcept override;
+};
+
+class Custom final : public ArbiterRequirement
+{
+  public:
+    explicit Custom (ArbiterRequirementPredicate predicate, const void *context)
+      : _predicate(std::move(predicate))
+      , _context(context)
+    {
+      assert(_predicate);
+    }
+
+    std::ostream &describe (std::ostream &os) const override
+    {
+      return os << "(custom predicate)";
+    }
+
+    std::unique_ptr<Base> clone () const override
+    {
+      return std::make_unique<Custom>(*this);
+    }
+
+    ArbiterRequirementSuitability satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const override;
+    std::unique_ptr<ArbiterRequirement> intersect (const ArbiterRequirement &rhs) const override;
+    bool operator== (const Arbiter::Base &other) const override;
+    size_t hash () const noexcept override;
+
+  private:
+    ArbiterRequirementPredicate _predicate;
+    const void *_context;
 };
 
 class Compound final : public ArbiterRequirement

--- a/src/Requirement.h
+++ b/src/Requirement.h
@@ -160,6 +160,27 @@ class Exactly final : public ArbiterRequirement
     size_t hash () const noexcept override;
 };
 
+class Compound final : public ArbiterRequirement
+{
+  public:
+    std::vector<std::shared_ptr<ArbiterRequirement>> _requirements;
+
+    explicit Compound (std::vector<std::shared_ptr<ArbiterRequirement>> requirements)
+      : _requirements(std::move(requirements))
+    {}
+
+    std::unique_ptr<Base> clone () const override
+    {
+      return std::make_unique<Compound>(*this);
+    }
+
+    ArbiterRequirementSuitability satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const override;
+    std::unique_ptr<ArbiterRequirement> intersect (const ArbiterRequirement &rhs) const override;
+    std::ostream &describe (std::ostream &os) const override;
+    bool operator== (const Arbiter::Base &other) const override;
+    size_t hash () const noexcept override;
+};
+
 } // namespace Requirement
 } // namespace Arbiter
 

--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -39,7 +39,7 @@ class DependencyGraph final
      */
     void addNode (ArbiterResolvedDependency node, const ArbiterRequirement &initialRequirement, const Optional<ArbiterProjectIdentifier> &dependent) noexcept(false)
     {
-      assert(initialRequirement.satisfiedBy(node._version._semanticVersion));
+      assert(initialRequirement.satisfiedBy(node._version));
 
       const NodeKey &key = node._project;
 
@@ -49,7 +49,7 @@ class DependencyGraph final
 
         // We need to unify our input with what was already there.
         if (auto newRequirement = initialRequirement.intersect(value.requirement())) {
-          if (!newRequirement->satisfiedBy(value._version._semanticVersion)) {
+          if (!newRequirement->satisfiedBy(value._version)) {
             throw Exception::UnsatisfiableConstraints("Cannot satisfy " + toString(*newRequirement) + " with " + toString(value._version));
           }
 
@@ -176,7 +176,7 @@ class DependencyGraph final
 
         void setRequirement (std::unique_ptr<ArbiterRequirement> requirement)
         {
-          assert(requirement->satisfiedBy(_version._semanticVersion));
+          assert(requirement->satisfiedBy(_version));
           _requirement = std::move(requirement);
         }
 
@@ -407,7 +407,7 @@ std::vector<ArbiterSelectedVersion> ArbiterResolver::availableVersionsSatisfying
   std::vector<ArbiterSelectedVersion> versions = fetchAvailableVersions(project)._versions;
 
   auto removeStart = std::remove_if(versions.begin(), versions.end(), [&requirement](const ArbiterSelectedVersion &version) {
-    return !requirement.satisfiedBy(version._semanticVersion);
+    return !requirement.satisfiedBy(version);
   });
 
   versions.erase(removeStart, versions.end());

--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -49,9 +49,20 @@ class DependencyGraph final
 
         // We need to unify our input with what was already there.
         if (auto newRequirement = initialRequirement.intersect(value.requirement())) {
-          // TODO: Handle ArbiterRequirementSuitabilityBestPossibleChoice
-          if (newRequirement->satisfiedBy(value._version) != ArbiterRequirementSuitabilityUnsuitable) {
+          ArbiterRequirementSuitability newSuitability = newRequirement->satisfiedBy(value._version);
+
+          if (newSuitability == ArbiterRequirementSuitabilityUnsuitable) {
             throw Exception::UnsatisfiableConstraints("Cannot satisfy " + toString(*newRequirement) + " with " + toString(value._version));
+          } else if (newSuitability != ArbiterRequirementSuitabilityBestPossibleChoice) {
+            // Let's see if the version of the provided node might be better.
+            ArbiterRequirementSuitability suitabilityWithGivenVersion = newRequirement->satisfiedBy(node._version);
+
+            if (suitabilityWithGivenVersion == ArbiterRequirementSuitabilityUnsuitable) {
+              throw Exception::UnsatisfiableConstraints("Cannot satisfy " + toString(*newRequirement) + " with " + toString(node._version));
+            } else if (suitabilityWithGivenVersion == ArbiterRequirementSuitabilityBestPossibleChoice) {
+              // Yep, it's wood. http://knowyourmeme.com/memes/identifying-wood
+              value._version = node._version;
+            }
           }
 
           value.setRequirement(std::move(newRequirement));
@@ -157,7 +168,7 @@ class DependencyGraph final
     struct NodeValue final
     {
       public:
-        const ArbiterSelectedVersion _version;
+        ArbiterSelectedVersion _version;
 
         NodeValue (ArbiterSelectedVersion version, const ArbiterRequirement &requirement)
           : _version(std::move(version))
@@ -406,10 +417,27 @@ bool ArbiterResolver::operator== (const Arbiter::Base &other) const
 std::vector<ArbiterSelectedVersion> ArbiterResolver::availableVersionsSatisfying (const ArbiterProjectIdentifier &project, const ArbiterRequirement &requirement) noexcept(false)
 {
   std::vector<ArbiterSelectedVersion> versions = fetchAvailableVersions(project)._versions;
+  std::vector<ArbiterSelectedVersion> bestPossible;
 
-  auto removeStart = std::remove_if(versions.begin(), versions.end(), [&requirement](const ArbiterSelectedVersion &version) {
-    return requirement.satisfiedBy(version) != ArbiterRequirementSuitabilityUnsuitable;
+  auto removeStart = std::remove_if(versions.begin(), versions.end(), [&requirement, &bestPossible](const ArbiterSelectedVersion &version) {
+    switch (requirement.satisfiedBy(version)) {
+      case ArbiterRequirementSuitabilityUnsuitable:
+        return true;
+
+      case ArbiterRequirementSuitabilitySuitable:
+        return false;
+
+      case ArbiterRequirementSuitabilityBestPossibleChoice:
+        bestPossible.emplace_back(version);
+        return false;
+    }
   });
+
+  if (!bestPossible.empty()) {
+    // Throw away versions which, although they may satisfy the requirement,
+    // aren't as good.
+    return bestPossible;
+  }
 
   versions.erase(removeStart, versions.end());
   return versions;

--- a/test/RequirementTest.cpp
+++ b/test/RequirementTest.cpp
@@ -1,9 +1,12 @@
 #include "Requirement.h"
 
+#include "TestValue.h"
+
 #include "gtest/gtest.h"
 
 using namespace Arbiter;
 using namespace Requirement;
+using namespace Testing;
 
 TEST(RequirementTest, AnyRequirement) {
   Any req;
@@ -11,10 +14,10 @@ TEST(RequirementTest, AnyRequirement) {
   EXPECT_EQ(req, Any());
   EXPECT_NE(req, AtLeast(ArbiterSemanticVersion(1, 2, 3)));
 
-  EXPECT_TRUE(req.satisfiedBy(ArbiterSemanticVersion(0, 0, 0)));
-  EXPECT_TRUE(req.satisfiedBy(ArbiterSemanticVersion(1, 2, 3)));
-  EXPECT_TRUE(req.satisfiedBy(ArbiterSemanticVersion(1, 2, 3, makeOptional("alpha.1"))));
-  EXPECT_TRUE(req.satisfiedBy(ArbiterSemanticVersion(1, 2, 3, makeOptional("alpha.1"), makeOptional("dailybuild"))));
+  EXPECT_TRUE(req.satisfiedBy(ArbiterSelectedVersion(ArbiterSemanticVersion(0, 0, 0), makeSharedUserValue<ArbiterSelectedVersion, EmptyTestValue>())));
+  EXPECT_TRUE(req.satisfiedBy(ArbiterSelectedVersion(ArbiterSemanticVersion(1, 2, 3), makeSharedUserValue<ArbiterSelectedVersion, EmptyTestValue>())));
+  EXPECT_TRUE(req.satisfiedBy(ArbiterSelectedVersion(ArbiterSemanticVersion(1, 2, 3, makeOptional("alpha.1")), makeSharedUserValue<ArbiterSelectedVersion, EmptyTestValue>())));
+  EXPECT_TRUE(req.satisfiedBy(ArbiterSelectedVersion(ArbiterSemanticVersion(1, 2, 3, makeOptional("alpha.1"), makeOptional("dailybuild")), makeSharedUserValue<ArbiterSelectedVersion, EmptyTestValue>())));
 }
 
 TEST(RequirementTest, AtLeastRequirement) {

--- a/test/TestValue.cpp
+++ b/test/TestValue.cpp
@@ -1,0 +1,106 @@
+#include "TestValue.h"
+
+#include "Hash.h"
+
+namespace Arbiter {
+namespace Testing {
+
+std::ostream &operator<< (std::ostream &os, const TestValue &value)
+{
+  return value.describe(os);
+}
+
+} // namespace Testing
+} // namespace Arbiter
+
+using namespace Arbiter;
+using namespace Testing;
+
+namespace {
+
+static bool equalTo (const void *first, const void *second)
+{
+  return *static_cast<const TestValue *>(first) == *static_cast<const TestValue *>(second);
+}
+
+static bool lessThan (const void *first, const void *second)
+{
+  return *static_cast<const TestValue *>(first) < *static_cast<const TestValue *>(second);
+}
+
+static size_t hash (const void *data)
+{
+  return static_cast<const TestValue *>(data)->hash();
+}
+
+static void destructor (void *data)
+{
+  delete static_cast<TestValue *>(data);
+}
+
+static char *createDescription (const void *data)
+{
+  return copyCString(toString(*static_cast<const TestValue *>(data))).release();
+}
+
+} // namespace
+
+ArbiterUserValue TestValue::convertToUserValue (std::unique_ptr<TestValue> testValue)
+{
+  ArbiterUserValue userValue;
+  userValue.data = testValue.release();
+  userValue.equalTo = &::equalTo;
+  userValue.lessThan = &::lessThan;
+  userValue.hash = &::hash;
+  userValue.destructor = &::destructor;
+  userValue.createDescription = &::createDescription;
+  return userValue;
+}
+
+bool EmptyTestValue::operator== (const TestValue &other) const
+{
+  return dynamic_cast<const EmptyTestValue *>(&other);
+}
+
+bool EmptyTestValue::operator< (const TestValue &other) const
+{
+  return !(*this == other);
+}
+
+size_t EmptyTestValue::hash () const
+{
+  return 4;
+}
+
+std::ostream &EmptyTestValue::describe (std::ostream &os) const
+{
+  return os << "EmptyTestValue";
+}
+
+bool StringTestValue::operator== (const TestValue &other) const
+{
+  if (auto ptr = dynamic_cast<const StringTestValue *>(&other)) {
+    return _str == ptr->_str;
+  } else {
+    return true;
+  }
+}
+
+bool StringTestValue::operator< (const TestValue &other) const
+{
+  if (auto ptr = dynamic_cast<const StringTestValue *>(&other)) {
+    return _str < ptr->_str;
+  } else {
+    return true;
+  }
+}
+
+size_t StringTestValue::hash () const
+{
+  return hashOf(_str);
+}
+
+std::ostream &StringTestValue::describe (std::ostream &os) const
+{
+  return os << _str;
+}

--- a/test/TestValue.h
+++ b/test/TestValue.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#ifndef __cplusplus
+#error "This file must be compiled as C++."
+#endif
+
+#include "Value.h"
+
+#include <memory>
+#include <ostream>
+#include <string>
+
+namespace Arbiter {
+namespace Testing {
+
+/**
+ * A C++ object capable of being an ArbiterUserValue.
+ */
+class TestValue
+{
+  public:
+    virtual ~TestValue () = default;
+
+    virtual bool operator== (const TestValue &) const = 0;
+    virtual bool operator< (const TestValue &) const = 0;
+    virtual std::ostream &describe (std::ostream &os) const = 0;
+    virtual size_t hash () const = 0;
+
+    static ArbiterUserValue convertToUserValue (std::unique_ptr<TestValue> testValue);
+};
+
+std::ostream &operator<< (std::ostream &os, const TestValue &value);
+
+class EmptyTestValue final : public TestValue
+{
+  public:
+    EmptyTestValue () = default;
+
+    bool operator== (const TestValue &other) const override;
+    bool operator< (const TestValue &other) const override;
+    size_t hash () const override;
+    std::ostream &describe (std::ostream &os) const override;
+};
+
+struct StringTestValue final : public TestValue
+{
+  public:
+    explicit StringTestValue (std::string str)
+      : _str(std::move(str))
+    {}
+
+    bool operator== (const TestValue &other) const override;
+    bool operator< (const TestValue &other) const override;
+    size_t hash () const override;
+    std::ostream &describe (std::ostream &os) const override;
+
+  private:
+    std::string _str;
+};
+
+template<typename Owner, typename Value, typename... Args>
+SharedUserValue<Owner> makeSharedUserValue (Args &&...args)
+{
+  return SharedUserValue<Owner>(TestValue::convertToUserValue(std::make_unique<Value>(std::forward<Args>(args)...)));
+}
+
+} // namespace Testing
+} // namespace Arbiter


### PR DESCRIPTION
This enables support for requirements like "pin to this named branch," where maybe a semantic version isn't available.