### PR TITLE
Add support for requirements and selected versions without a semantic version

### DIFF
--- a/bindings/swift/Arbiter/Requirement.swift
+++ b/bindings/swift/Arbiter/Requirement.swift
@@ -4,8 +4,9 @@ public enum Specifier
   case AtLeast(SemanticVersion)
   case CompatibleWith(SemanticVersion, ArbiterRequirementStrictness)
   case Exactly(SemanticVersion)
-  indirect case Compound([Specifier])
+  case Unversioned(ArbiterUserValue)
   // TODO: Custom
+  indirect case Compound([Specifier])
 }
 
 public final class Requirement : CObject
@@ -26,6 +27,9 @@ public final class Requirement : CObject
 
     case let .Exactly(version):
       ptr = ArbiterCreateRequirementExactly(version.pointer)
+
+    case let .Unversioned(metadata):
+      ptr = ArbiterCreateRequirementUnversioned(metadata)
 
     case let .Compound(specifiers):
       let requirements = specifiers.map { s in Requirement(s) }

--- a/include/arbiter/Requirement.h
+++ b/include/arbiter/Requirement.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#include <arbiter/Value.h>
+
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -78,6 +80,14 @@ ArbiterRequirement *ArbiterCreateRequirementCompatibleWith (const struct Arbiter
  * The returned requirement must be freed with ArbiterFree().
  */
 ArbiterRequirement *ArbiterCreateRequirementExactly (const struct ArbiterSemanticVersion *version);
+
+/**
+ * Creates a requirement which only matches against `ArbiterSelectedVersion`s
+ * that have metadata equal to `metadata`.
+ *
+ * The returned requirement must be freed with ArbiterFree().
+ */
+ArbiterRequirement *ArbiterCreateRequirementUnversioned (ArbiterUserValue metadata);
 
 /**
  * Creates a requirement which will evaluate a custom predicate whenever

--- a/include/arbiter/Resolver.h
+++ b/include/arbiter/Resolver.h
@@ -47,6 +47,23 @@ typedef struct
    * in which case Arbiter will be responsible for freeing the string.
    */
   struct ArbiterSelectedVersionList *(*createAvailableVersionsList)(const ArbiterResolver *resolver, const struct ArbiterProjectIdentifier *project, char **error);
+
+  /**
+   * Requests the selected version which corresponds to the given metadata.
+   *
+   * This behavior can be used to implement lookup of versions which are not
+   * known in advance (i.e., those which would not appear in the result of
+   * `createAvailableVersionsList`). For example, it is impractical to list all
+   * commit hashes from a version control system, but they could be looked up by
+   * hash here.
+   *
+   * This behavior is optional, and may be set to NULL if unsupported or
+   * unnecessary.
+   *
+   * Returns a selected version, or NULL if one corresponding to the metadata
+   * could not be found.
+   */
+  struct ArbiterSelectedVersion *(*createSelectedVersionForMetadata)(const ArbiterResolver *resolver, const void *metadata);
 } ArbiterResolverBehaviors;
 
 /**

--- a/include/arbiter/Version.h
+++ b/include/arbiter/Version.h
@@ -87,12 +87,17 @@ typedef struct ArbiterSelectedVersion ArbiterSelectedVersion;
 /**
  * Creates a selected version which corresponds to the given semantic version.
  *
+ * `semanticVersion` may be NULL to represent a selected version that has
+ * metadata but no semantic version component; for example, to use with
+ * ArbiterCreateRequirementUnversioned().
+ *
  * The returned version must be freed with ArbiterFree().
  */
 ArbiterSelectedVersion *ArbiterCreateSelectedVersion (const ArbiterSemanticVersion *semanticVersion, ArbiterUserValue metadata);
 
 /**
- * Returns the semantic version which corresponds to the given selected version.
+ * Returns the semantic version which corresponds to the given selected version,
+ * or NULL if there is no semantic version component.
  *
  * The returned pointer is only guaranteed to remain valid for the current
  * scope.

--- a/src/Optional.h
+++ b/src/Optional.h
@@ -131,6 +131,18 @@ struct Optional final
     }
 
     /**
+     * Creates an Optional from a pointer which may or may not be null.
+     */
+    static Optional fromPointer (const T *pointer) noexcept(std::is_nothrow_copy_constructible<T>::value)
+    {
+      if (pointer) {
+        return Optional(*pointer);
+      } else {
+        return Optional();
+      }
+    }
+
+    /**
      * Returns true if this Optional contains a value, or false if it is empty.
      */
     explicit operator bool () const noexcept

--- a/src/Requirement.cpp
+++ b/src/Requirement.cpp
@@ -57,6 +57,11 @@ std::unique_ptr<ArbiterRequirement> ArbiterRequirement::cloneRequirement () cons
   return std::unique_ptr<ArbiterRequirement>(dynamic_cast<ArbiterRequirement *>(clone().release()));
 }
 
+void ArbiterRequirement::visit (Arbiter::Requirement::Visitor &visitor) const
+{
+  visitor(*this);
+}
+
 namespace Arbiter {
 namespace Requirement {
 
@@ -472,6 +477,15 @@ size_t Compound::hash () const noexcept
   }
 
   return value;
+}
+
+void Compound::visit (Visitor &visitor) const
+{
+  ArbiterRequirement::visit(visitor);
+
+  for (const auto &requirement : _requirements) {
+    requirement->visit(visitor);
+  }
 }
 
 std::unique_ptr<ArbiterRequirement> Any::intersect (const ArbiterRequirement &rhs) const

--- a/src/Requirement.h
+++ b/src/Requirement.h
@@ -92,7 +92,11 @@ class AtLeast final : public ArbiterRequirement
 
     bool satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const override
     {
-      return satisfiedBy(selectedVersion._semanticVersion);
+      if (selectedVersion._semanticVersion) {
+        return satisfiedBy(*selectedVersion._semanticVersion);
+      } else {
+        return false;
+      }
     }
 
     std::unique_ptr<Base> clone () const override
@@ -124,7 +128,11 @@ class CompatibleWith final : public ArbiterRequirement
 
     bool satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const override
     {
-      return satisfiedBy(selectedVersion._semanticVersion);
+      if (selectedVersion._semanticVersion) {
+        return satisfiedBy(*selectedVersion._semanticVersion);
+      } else {
+        return false;
+      }
     }
 
     std::unique_ptr<Base> clone () const override
@@ -153,7 +161,11 @@ class Exactly final : public ArbiterRequirement
 
     bool satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const override
     {
-      return satisfiedBy(selectedVersion._semanticVersion);
+      if (selectedVersion._semanticVersion) {
+        return satisfiedBy(*selectedVersion._semanticVersion);
+      } else {
+        return false;
+      }
     }
 
     std::unique_ptr<Base> clone () const override

--- a/src/Requirement.h
+++ b/src/Requirement.h
@@ -180,6 +180,32 @@ class Exactly final : public ArbiterRequirement
     size_t hash () const noexcept override;
 };
 
+class Unversioned final : public ArbiterRequirement
+{
+  public:
+    // This metadata is not really part of the requirement type; it is
+    // associated with the selected version.
+    using Metadata = Arbiter::SharedUserValue<ArbiterSelectedVersion>;
+
+    Metadata _metadata;
+
+    explicit Unversioned (Metadata metadata)
+      : _metadata(std::move(metadata))
+    {}
+
+    std::unique_ptr<Base> clone () const override
+    {
+      return std::make_unique<Unversioned>(*this);
+    }
+
+    std::ostream &describe (std::ostream &os) const override;
+    bool satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const override;
+    std::unique_ptr<ArbiterRequirement> intersect (const ArbiterRequirement &rhs) const override;
+    bool operator== (const Arbiter::Base &other) const override;
+    size_t hash () const noexcept override;
+
+};
+
 class Custom final : public ArbiterRequirement
 {
   public:

--- a/src/Requirement.h
+++ b/src/Requirement.h
@@ -13,6 +13,14 @@
 #include <memory>
 #include <ostream>
 
+namespace Arbiter {
+namespace Requirement {
+
+class Visitor;
+
+} // namespace Requirement
+} // namespace Arbiter
+
 struct ArbiterRequirement : public Arbiter::Base
 {
   public:
@@ -35,12 +43,30 @@ struct ArbiterRequirement : public Arbiter::Base
      */
     virtual std::unique_ptr<ArbiterRequirement> intersect (const ArbiterRequirement &rhs) const = 0;
 
+    /**
+     * Visits the requirement, then any child requirements.
+     *
+     * The default implementation simply visits this requirement.
+     */
+    virtual void visit (Arbiter::Requirement::Visitor &visitor) const;
+
     std::unique_ptr<ArbiterRequirement> cloneRequirement () const;
     virtual size_t hash () const noexcept = 0;
 };
 
 namespace Arbiter {
 namespace Requirement {
+
+/**
+ * Base class for objects that want to visit requirements.
+ */
+class Visitor
+{
+  public:
+    virtual ~Visitor () = default;
+
+    virtual void operator() (const ArbiterRequirement &requirement) = 0;
+};
 
 /**
  * A requirement satisfied by any version.
@@ -255,6 +281,7 @@ class Compound final : public ArbiterRequirement
     std::ostream &describe (std::ostream &os) const override;
     bool operator== (const Arbiter::Base &other) const override;
     size_t hash () const noexcept override;
+    void visit (Visitor &visitor) const override;
 };
 
 } // namespace Requirement

--- a/src/Resolver.h
+++ b/src/Resolver.h
@@ -45,6 +45,13 @@ struct ArbiterResolver final : public Arbiter::Base
     ArbiterSelectedVersionList fetchAvailableVersions (const ArbiterProjectIdentifier &project) noexcept(false);
 
     /**
+     * Fetches a selected version for the given metadata string.
+     *
+     * Returns the selected version if found, or else None.
+     */
+    Arbiter::Optional<ArbiterSelectedVersion> fetchSelectedVersionForMetadata (const Arbiter::SharedUserValue<ArbiterSelectedVersion> &metadata);
+
+    /**
      * Computes a list of available versions for the specified project which
      * satisfy the given requirement.
      */

--- a/src/Version.h
+++ b/src/Version.h
@@ -65,10 +65,10 @@ struct ArbiterSelectedVersion final : public Arbiter::Base
   public:
     using Metadata = Arbiter::SharedUserValue<ArbiterSelectedVersion>;
 
-    ArbiterSemanticVersion _semanticVersion;
+    Arbiter::Optional<ArbiterSemanticVersion> _semanticVersion;
     Metadata _metadata;
 
-    ArbiterSelectedVersion (ArbiterSemanticVersion semanticVersion, Metadata metadata)
+    ArbiterSelectedVersion (Arbiter::Optional<ArbiterSemanticVersion> semanticVersion, Metadata metadata)
       : _semanticVersion(std::move(semanticVersion))
       , _metadata(std::move(metadata))
     {}
@@ -77,24 +77,21 @@ struct ArbiterSelectedVersion final : public Arbiter::Base
     std::ostream &describe (std::ostream &os) const override;
     bool operator== (const Arbiter::Base &other) const override;
 
-    bool operator< (const ArbiterSelectedVersion &other) const
+    bool operator< (const ArbiterSelectedVersion &other) const;
+
+    bool operator> (const ArbiterSelectedVersion &other) const
     {
-      return _semanticVersion < other._semanticVersion;
+      return other < *this;
     }
 
     bool operator<= (const ArbiterSelectedVersion &other) const
     {
-      return _semanticVersion <= other._semanticVersion;
-    }
-
-    bool operator> (const ArbiterSelectedVersion &other) const
-    {
-      return _semanticVersion > other._semanticVersion;
+      return !(other < *this);
     }
 
     bool operator>= (const ArbiterSelectedVersion &other) const
     {
-      return _semanticVersion >= other._semanticVersion;
+      return !(*this < other);
     }
 };
 

--- a/test/ResolverTest.cpp
+++ b/test/ResolverTest.cpp
@@ -103,9 +103,7 @@ const ArbiterResolvedDependency &findResolved (const ArbiterResolvedDependencyGr
 } // namespace
 
 TEST(ResolverTest, ResolvesEmptyDependencies) {
-  ArbiterResolverBehaviors behaviors;
-  behaviors.createDependencyList = &createEmptyDependencyList;
-  behaviors.createAvailableVersionsList = &createEmptyAvailableVersionsList;
+  ArbiterResolverBehaviors behaviors{&createEmptyDependencyList, &createEmptyAvailableVersionsList, nullptr};
 
   ArbiterResolver resolver(behaviors, ArbiterDependencyList(), nullptr);
 
@@ -116,9 +114,7 @@ TEST(ResolverTest, ResolvesEmptyDependencies) {
 }
 
 TEST(ResolverTest, ResolvesOneDependency) {
-  ArbiterResolverBehaviors behaviors;
-  behaviors.createDependencyList = &createEmptyDependencyList;
-  behaviors.createAvailableVersionsList = &createMajorVersionsList;
+  ArbiterResolverBehaviors behaviors{&createEmptyDependencyList, &createMajorVersionsList, nullptr};
 
   std::vector<ArbiterDependency> dependencies;
   dependencies.emplace_back(emptyProjectIdentifier(), Requirement::AtLeast(ArbiterSemanticVersion(2, 0, 0)));
@@ -134,9 +130,7 @@ TEST(ResolverTest, ResolvesOneDependency) {
 
 TEST(ResolverTest, ResolvesMultipleDependencies)
 {
-  ArbiterResolverBehaviors behaviors;
-  behaviors.createDependencyList = &createEmptyDependencyList;
-  behaviors.createAvailableVersionsList = &createMajorVersionsList;
+  ArbiterResolverBehaviors behaviors{&createEmptyDependencyList, &createMajorVersionsList, nullptr};
 
   std::vector<ArbiterDependency> dependencies;
   dependencies.emplace_back(makeProjectIdentifier("B"), Requirement::CompatibleWith(ArbiterSemanticVersion(2, 0, 0), ArbiterRequirementStrictnessStrict));
@@ -155,9 +149,7 @@ TEST(ResolverTest, ResolvesMultipleDependencies)
 
 TEST(ResolverTest, ResolvesTransitiveDependencies)
 {
-  ArbiterResolverBehaviors behaviors;
-  behaviors.createDependencyList = &createTransitiveDependencyList;
-  behaviors.createAvailableVersionsList = &createVariedVersionsList;
+  ArbiterResolverBehaviors behaviors{&createTransitiveDependencyList, &createVariedVersionsList, nullptr};
 
   std::vector<ArbiterDependency> dependencies;
   dependencies.emplace_back(makeProjectIdentifier("ancestor"), Requirement::Exactly(ArbiterSemanticVersion(1, 0, 1, makeOptional("alpha"))));

--- a/test/ResolverTest.cpp
+++ b/test/ResolverTest.cpp
@@ -129,7 +129,7 @@ TEST(ResolverTest, ResolvesOneDependency) {
   ASSERT_EQ(resolved.depth(), 1);
   EXPECT_EQ(resolved.count(), 1);
   EXPECT_EQ(resolved._depths.front().begin()->_project, emptyProjectIdentifier());
-  EXPECT_EQ(resolved._depths.front().begin()->_version._semanticVersion, ArbiterSemanticVersion(3, 0, 0));
+  EXPECT_EQ(resolved._depths.front().begin()->_version._semanticVersion, makeOptional(ArbiterSemanticVersion(3, 0, 0)));
 }
 
 TEST(ResolverTest, ResolvesMultipleDependencies)
@@ -148,9 +148,9 @@ TEST(ResolverTest, ResolvesMultipleDependencies)
   ArbiterResolvedDependencyGraph resolved = resolver.resolve();
   ASSERT_EQ(resolved.depth(), 1);
   EXPECT_EQ(resolved.count(), 3);
-  EXPECT_EQ(findResolved(resolved, 0, "A")._version._semanticVersion, ArbiterSemanticVersion(3, 0, 0));
-  EXPECT_EQ(findResolved(resolved, 0, "B")._version._semanticVersion, ArbiterSemanticVersion(2, 0, 0));
-  EXPECT_EQ(findResolved(resolved, 0, "C")._version._semanticVersion, ArbiterSemanticVersion(1, 0, 0));
+  EXPECT_EQ(findResolved(resolved, 0, "A")._version._semanticVersion, makeOptional(ArbiterSemanticVersion(3, 0, 0)));
+  EXPECT_EQ(findResolved(resolved, 0, "B")._version._semanticVersion, makeOptional(ArbiterSemanticVersion(2, 0, 0)));
+  EXPECT_EQ(findResolved(resolved, 0, "C")._version._semanticVersion, makeOptional(ArbiterSemanticVersion(1, 0, 0)));
 }
 
 TEST(ResolverTest, ResolvesTransitiveDependencies)
@@ -168,12 +168,12 @@ TEST(ResolverTest, ResolvesTransitiveDependencies)
   ArbiterResolvedDependencyGraph resolved = resolver.resolve();
   ASSERT_EQ(resolved.depth(), 3);
   EXPECT_EQ(resolved.count(), 6);
-  EXPECT_EQ(findResolved(resolved, 2, "ancestor")._version._semanticVersion, ArbiterSemanticVersion(1, 0, 1, makeOptional("alpha")));
-  EXPECT_EQ(findResolved(resolved, 1, "middle")._version._semanticVersion, ArbiterSemanticVersion(1, 3, 0));
-  EXPECT_EQ(findResolved(resolved, 1, "parent")._version._semanticVersion, ArbiterSemanticVersion(1, 3, 0));
-  EXPECT_EQ(findResolved(resolved, 0, "leaf")._version._semanticVersion, ArbiterSemanticVersion(0, 2, 3));
-  EXPECT_EQ(findResolved(resolved, 0, "leaf_majors_only")._version._semanticVersion, ArbiterSemanticVersion(2, 0, 0));
-  EXPECT_EQ(findResolved(resolved, 0, "leaf_dailybuild")._version._semanticVersion, ArbiterSemanticVersion(2, 1, 0, None(), makeOptional("dailybuild")));
+  EXPECT_EQ(findResolved(resolved, 2, "ancestor")._version._semanticVersion, makeOptional(ArbiterSemanticVersion(1, 0, 1, makeOptional("alpha"))));
+  EXPECT_EQ(findResolved(resolved, 1, "middle")._version._semanticVersion, makeOptional(ArbiterSemanticVersion(1, 3, 0)));
+  EXPECT_EQ(findResolved(resolved, 1, "parent")._version._semanticVersion, makeOptional(ArbiterSemanticVersion(1, 3, 0)));
+  EXPECT_EQ(findResolved(resolved, 0, "leaf")._version._semanticVersion, makeOptional(ArbiterSemanticVersion(0, 2, 3)));
+  EXPECT_EQ(findResolved(resolved, 0, "leaf_majors_only")._version._semanticVersion, makeOptional(ArbiterSemanticVersion(2, 0, 0)));
+  EXPECT_EQ(findResolved(resolved, 0, "leaf_dailybuild")._version._semanticVersion, makeOptional(ArbiterSemanticVersion(2, 1, 0, None(), makeOptional("dailybuild"))));
 }
 
 #if 0


### PR DESCRIPTION
This is useful to match upon and provide versions using only metadata, part of implementing "unpinned" versions (like picking a branch).

cc @mdiep 