### PR TITLE
Allow requirements to carry a priority

### DIFF
--- a/bindings/swift/Arbiter/Requirement.swift
+++ b/bindings/swift/Arbiter/Requirement.swift
@@ -7,6 +7,7 @@ public enum Specifier
   case Unversioned(ArbiterUserValue)
   // TODO: Custom
   indirect case Compound([Specifier])
+  indirect case Prioritized(Specifier, Int)
 }
 
 public final class Requirement : CObject
@@ -38,6 +39,10 @@ public final class Requirement : CObject
       ptr = requirementPtrs.withUnsafeBufferPointer { buffer in
         return ArbiterCreateRequirementCompound(buffer.baseAddress, buffer.count)
       }
+
+    case let .Prioritized(specifier, priority):
+      let inner = Requirement(specifier)
+      ptr = ArbiterCreateRequirementPrioritized(inner.pointer, Int32(priority))
     }
 
     self.init(ptr, shouldCopy: false)

--- a/include/arbiter/Requirement.h
+++ b/include/arbiter/Requirement.h
@@ -150,6 +150,12 @@ ArbiterRequirement *ArbiterCreateRequirementPrioritized (const ArbiterRequiremen
  */
 bool ArbiterRequirementSatisfiedBy (const ArbiterRequirement *requirement, const struct ArbiterSelectedVersion *version);
 
+/**
+ * Returns the priority of the given requirement. See
+ * ArbiterCreateRequirementPrioritized() for more information.
+ */
+int ArbiterRequirementPriority (const ArbiterRequirement *requirement);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/arbiter/Requirement.h
+++ b/include/arbiter/Requirement.h
@@ -113,6 +113,39 @@ ArbiterRequirement *ArbiterCreateRequirementCustom (ArbiterRequirementPredicate 
 ArbiterRequirement *ArbiterCreateRequirementCompound (const ArbiterRequirement * const *requirements, size_t count);
 
 /**
+ * Creates a requirement with a custom priority, changing how the base
+ * requirement intersects with other requirements in the dependency graph.
+ *
+ * Normally, if two requirements A and B are found for the same project in the
+ * graph, they are intersected to create a requirement which satisfies both
+ * A and B. If no intersection is possible, dependency resolution fails.
+ *
+ * Priorities short-circuit this intersection process. If requirement A has
+ * a lower _priority index_ (meaning that it is higher priority) than
+ * requirement B: requirement A will be used, requirement B will be discarded,
+ * and no intersection will be performed.
+ *
+ * **This can lead to surprising behavior that violates users' expectations**,
+ * but is nonetheless occasionally useful. For example, users sometimes want to
+ * be able to specify a particular version to use which lies outside of any
+ * semantic versioning scheme (e.g., an arbitrary branch or local checkout), in
+ * which case it makes sense to disable some semantic version requirements in
+ * the dependency graph.
+ *
+ * baseRequirement - A requirement specifying which versions will satisfy the
+ *                   new requirement. Must not be NULL.
+ * priorityIndex   - A "priority index" for the new requirement. Lower numbers
+ *                   indicate higher priority (just like setpriority() on Unix).
+ *                   Requirements without an explicit priority set are assumed
+ *                   to have priority index 0, meaning negative priorities will
+ *                   override the default and positive priorities will _be
+ *                   overridden_ by the default.
+ *
+ * The returned requirement must be freed with ArbiterFree().
+ */
+ArbiterRequirement *ArbiterCreateRequirementPrioritized (const ArbiterRequirement *baseRequirement, int priorityIndex);
+
+/**
  * Determines whether the given requirement is satisfied by the given version.
  */
 bool ArbiterRequirementSatisfiedBy (const ArbiterRequirement *requirement, const struct ArbiterSelectedVersion *version);

--- a/include/arbiter/Requirement.h
+++ b/include/arbiter/Requirement.h
@@ -132,6 +132,12 @@ ArbiterRequirement *ArbiterCreateRequirementCompound (const ArbiterRequirement *
  * which case it makes sense to disable some semantic version requirements in
  * the dependency graph.
  *
+ * _Note:_ prioritized requirements may be used to filter the list of available
+ * versions, even if they are lower priority than the default and may get
+ * discarded. This means that requirements should avoid rejecting valid versions
+ * for the project being considered, or else an unsatisfiable constraints error
+ * may result.
+ *
  * baseRequirement - A requirement specifying which versions will satisfy the
  *                   new requirement. Must not be NULL.
  * priorityIndex   - A "priority index" for the new requirement. Lower numbers

--- a/src/Requirement.cpp
+++ b/src/Requirement.cpp
@@ -47,6 +47,11 @@ ArbiterRequirement *ArbiterCreateRequirementCompound (const ArbiterRequirement *
   return new Arbiter::Requirement::Compound(std::move(vec));
 }
 
+ArbiterRequirement *ArbiterCreateRequirementPrioritized (const ArbiterRequirement *baseRequirement, int priorityIndex)
+{
+  return new Arbiter::Requirement::Prioritized(baseRequirement->cloneRequirement(), priorityIndex);
+}
+
 bool ArbiterRequirementSatisfiedBy (const ArbiterRequirement *requirement, const ArbiterSelectedVersion *version)
 {
   return requirement->satisfiedBy(*version);
@@ -253,6 +258,40 @@ struct Intersect<Compound, Other> final
   }
 };
 
+template<>
+struct Intersect<Prioritized, Prioritized> final
+{
+  using Result = std::unique_ptr<ArbiterRequirement>;
+
+  Result operator() (const Prioritized &lhs, const Prioritized &rhs) const
+  {
+    if (lhs._priority < rhs._priority) {
+      return lhs.cloneRequirement();
+    } else if (lhs._priority > rhs._priority) {
+      return rhs.cloneRequirement();
+    } else {
+      return lhs._requirement->intersect(*rhs._requirement);
+    }
+  }
+};
+
+template<typename Other>
+struct Intersect<Prioritized, Other> final
+{
+  using Result = std::unique_ptr<ArbiterRequirement>;
+
+  Result operator() (const Prioritized &prioritized, const Other &other) const
+  {
+    if (prioritized._priority < 0) {
+      return prioritized.cloneRequirement();
+    } else if (prioritized._priority > 0) {
+      return other.cloneRequirement();
+    } else {
+      return prioritized._requirement->intersect(other);
+    }
+  }
+};
+
 const std::type_info &any = typeid(Any);
 const std::type_info &atLeast = typeid(AtLeast);
 const std::type_info &compatibleWith = typeid(CompatibleWith);
@@ -260,6 +299,7 @@ const std::type_info &exactly = typeid(Exactly);
 const std::type_info &unversioned = typeid(Unversioned);
 const std::type_info &custom = typeid(Custom);
 const std::type_info &compound = typeid(Compound);
+const std::type_info &prioritized = typeid(Prioritized);
 
 template<typename Left>
 std::unique_ptr<ArbiterRequirement> intersectRight(const Left &lhs, const ArbiterRequirement &rhs)
@@ -278,6 +318,8 @@ std::unique_ptr<ArbiterRequirement> intersectRight(const Left &lhs, const Arbite
     return Intersect<Left, Custom>()(lhs, dynamic_cast<const Custom &>(rhs));
   } else if (typeid(rhs) == compound) {
     return Intersect<Left, Compound>()(lhs, dynamic_cast<const Compound &>(rhs));
+  } else if (typeid(rhs) == prioritized) {
+    return Intersect<Left, Prioritized>()(lhs, dynamic_cast<const Prioritized &>(rhs));
   } else {
     throw std::invalid_argument("Unrecognized type for requirement: " + toString(rhs));
   }
@@ -488,6 +530,36 @@ void Compound::visit (Visitor &visitor) const
   }
 }
 
+bool Prioritized::satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const
+{
+  return _requirement->satisfiedBy(selectedVersion);
+}
+
+std::ostream &Prioritized::describe (std::ostream &os) const
+{
+  return os << *_requirement << " (priority " << _priority << ")";
+}
+
+bool Prioritized::operator== (const Arbiter::Base &other) const
+{
+  if (auto *ptr = dynamic_cast<const Prioritized *>(&other)) {
+    return *_requirement == *ptr->_requirement && _priority == ptr->_priority;
+  } else {
+    return false;
+  }
+}
+
+size_t Prioritized::hash () const noexcept
+{
+  return hashOf(*_requirement) ^ hashOf(_priority);
+}
+
+void Prioritized::visit (Visitor &visitor) const
+{
+  ArbiterRequirement::visit(visitor);
+  _requirement->visit(visitor);
+}
+
 std::unique_ptr<ArbiterRequirement> Any::intersect (const ArbiterRequirement &rhs) const
 {
   return intersectRight<Any>(*this, rhs);
@@ -521,6 +593,11 @@ std::unique_ptr<ArbiterRequirement> Custom::intersect (const ArbiterRequirement 
 std::unique_ptr<ArbiterRequirement> Compound::intersect (const ArbiterRequirement &rhs) const
 {
   return intersectRight<Compound>(*this, rhs);
+}
+
+std::unique_ptr<ArbiterRequirement> Prioritized::intersect (const ArbiterRequirement &rhs) const
+{
+  return intersectRight<Prioritized>(*this, rhs);
 }
 
 } // namespace Requirement

--- a/src/Requirement.h
+++ b/src/Requirement.h
@@ -284,6 +284,30 @@ class Compound final : public ArbiterRequirement
     void visit (Visitor &visitor) const override;
 };
 
+class Prioritized final : public ArbiterRequirement
+{
+  public:
+    std::shared_ptr<ArbiterRequirement> _requirement;
+    int _priority;
+
+    explicit Prioritized (std::shared_ptr<ArbiterRequirement> requirement, int priority)
+      : _requirement(std::move(requirement))
+      , _priority(priority)
+    {}
+
+    std::unique_ptr<Base> clone () const override
+    {
+      return std::make_unique<Prioritized>(*this);
+    }
+
+    bool satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const override;
+    std::unique_ptr<ArbiterRequirement> intersect (const ArbiterRequirement &rhs) const override;
+    std::ostream &describe (std::ostream &os) const override;
+    bool operator== (const Arbiter::Base &other) const override;
+    size_t hash () const noexcept override;
+    void visit (Visitor &visitor) const override;
+};
+
 } // namespace Requirement
 } // namespace Arbiter
 

--- a/src/Requirement.h
+++ b/src/Requirement.h
@@ -31,6 +31,14 @@ struct ArbiterRequirement : public Arbiter::Base
     virtual bool satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const = 0;
 
     /**
+     * Returns the priority of this requirement.
+     */
+    virtual int priority () const noexcept
+    {
+      return 0;
+    }
+
+    /**
      * Attempts to create a requirement which expresses the intersection of this
      * requirement and the given one
      *
@@ -229,7 +237,6 @@ class Unversioned final : public ArbiterRequirement
     std::unique_ptr<ArbiterRequirement> intersect (const ArbiterRequirement &rhs) const override;
     bool operator== (const Arbiter::Base &other) const override;
     size_t hash () const noexcept override;
-
 };
 
 class Custom final : public ArbiterRequirement
@@ -276,6 +283,12 @@ class Compound final : public ArbiterRequirement
       return std::make_unique<Compound>(*this);
     }
 
+    /**
+     * Returns the minimum priority index of all the requirements held by this
+     * compound requirement.
+     */
+    int priority () const noexcept override;
+
     bool satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const override;
     std::unique_ptr<ArbiterRequirement> intersect (const ArbiterRequirement &rhs) const override;
     std::ostream &describe (std::ostream &os) const override;
@@ -288,7 +301,6 @@ class Prioritized final : public ArbiterRequirement
 {
   public:
     std::shared_ptr<ArbiterRequirement> _requirement;
-    int _priority;
 
     explicit Prioritized (std::shared_ptr<ArbiterRequirement> requirement, int priority)
       : _requirement(std::move(requirement))
@@ -300,12 +312,20 @@ class Prioritized final : public ArbiterRequirement
       return std::make_unique<Prioritized>(*this);
     }
 
+    int priority () const noexcept override
+    {
+      return _priority;
+    }
+
     bool satisfiedBy (const ArbiterSelectedVersion &selectedVersion) const override;
     std::unique_ptr<ArbiterRequirement> intersect (const ArbiterRequirement &rhs) const override;
     std::ostream &describe (std::ostream &os) const override;
     bool operator== (const Arbiter::Base &other) const override;
     size_t hash () const noexcept override;
     void visit (Visitor &visitor) const override;
+
+  private:
+    int _priority;
 };
 
 } // namespace Requirement

--- a/test/ResolverTest.cpp
+++ b/test/ResolverTest.cpp
@@ -192,7 +192,7 @@ TEST(ResolverTest, ResolvesPrioritizedUnversionedRequirements)
   std::vector<ArbiterDependency> dependencies;
   dependencies.emplace_back(makeProjectIdentifier("ancestor"), makeUnversionedRequirement("ancestor-branch"));
   dependencies.emplace_back(makeProjectIdentifier("middle"), makePrioritizedRequirement(makeUnversionedRequirement("middle-branch"), -1));
-  dependencies.emplace_back(makeProjectIdentifier("leaf"), makePrioritizedRequirement(makeUnversionedRequirement("this-will-be-discarded"), 1));
+  dependencies.emplace_back(makeProjectIdentifier("parent"), makePrioritizedRequirement(Requirement::CompatibleWith(ArbiterSemanticVersion(1, 2, 3), ArbiterRequirementStrictnessStrict), 1));
 
   ArbiterResolver resolver(behaviors, ArbiterDependencyList(std::move(dependencies)), nullptr);
 

--- a/test/TestValue.h
+++ b/test/TestValue.h
@@ -4,6 +4,7 @@
 #error "This file must be compiled as C++."
 #endif
 
+#include "Optional.h"
 #include "Value.h"
 
 #include <memory>
@@ -45,6 +46,8 @@ class EmptyTestValue final : public TestValue
 struct StringTestValue final : public TestValue
 {
   public:
+    std::string _str;
+
     explicit StringTestValue (std::string str)
       : _str(std::move(str))
     {}
@@ -53,15 +56,19 @@ struct StringTestValue final : public TestValue
     bool operator< (const TestValue &other) const override;
     size_t hash () const override;
     std::ostream &describe (std::ostream &os) const override;
-
-  private:
-    std::string _str;
 };
 
 template<typename Owner, typename Value, typename... Args>
 SharedUserValue<Owner> makeSharedUserValue (Args &&...args)
 {
   return SharedUserValue<Owner>(TestValue::convertToUserValue(std::make_unique<Value>(std::forward<Args>(args)...)));
+}
+
+template<typename Value>
+const Value &fromUserValue (const void *pointer) noexcept(false)
+{
+  const auto &value = *static_cast<const TestValue *>(pointer);
+  return dynamic_cast<const Value &>(value);
 }
 
 } // namespace Testing


### PR DESCRIPTION
Priority is used to determine which requirements are eligible for intersection. Requirements in two different priority bands will never be intersected.

This can be used to implement unpinned versions like a branch or commit hash, by creating a requirement which is higher priority (a lower numeric index) than the default.

cc @mdiep 