### PR TITLE
Choose more appropriate collection types in implementation

### DIFF
--- a/include/arbiter/Dependency.h
+++ b/include/arbiter/Dependency.h
@@ -163,7 +163,8 @@ size_t ArbiterResolvedDependencyGraphCountAtDepth (const ArbiterResolvedDependen
  * zero-based "depth index," into the C array `buffer`, which must have enough
  * space to contain ArbiterResolvedDependencyGraphCountAtDepth() elements.
  *
- * This operation does not guarantee a specific ordering to the copied items.
+ * This operation guarantees that resolved dependencies will appear in the
+ * buffer in ascending order of their project identifiers.
  *
  * The copied pointers are guaranteed to remain valid until the
  * ArbiterResolvedDependencyGraph they were obtained from is freed.

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -215,6 +215,11 @@ bool ArbiterResolvedDependency::operator== (const Arbiter::Base &other) const
   return _project == ptr->_project && _version == ptr->_version;
 }
 
+bool ArbiterResolvedDependency::operator< (const ArbiterResolvedDependency &other) const
+{
+  return _project < other._project;
+}
+
 size_t ArbiterResolvedDependencyGraph::count () const
 {
   size_t accum = 0;

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -13,8 +13,8 @@
 #include <functional>
 #include <memory>
 #include <ostream>
+#include <set>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 struct ArbiterRequirement;
@@ -110,6 +110,8 @@ struct ArbiterResolvedDependency final : public Arbiter::Base
     std::unique_ptr<Arbiter::Base> clone () const override;
     std::ostream &describe (std::ostream &os) const override;
     bool operator== (const Arbiter::Base &other) const override;
+
+    bool operator< (const ArbiterResolvedDependency &other) const;
 };
 
 namespace std {
@@ -127,9 +129,7 @@ struct ArbiterResolvedDependencyGraph final : public Arbiter::Base
 {
   public:
     using SortedEdgesMap = std::unordered_map<ArbiterProjectIdentifier, std::vector<ArbiterProjectIdentifier>>;
-
-    // TODO: Should this be ordered?
-    using DepthSet = std::unordered_set<ArbiterResolvedDependency>;
+    using DepthSet = std::set<ArbiterResolvedDependency>;
 
     std::vector<DepthSet> _depths;
     SortedEdgesMap _edges;

--- a/src/Requirement.cpp
+++ b/src/Requirement.cpp
@@ -235,7 +235,10 @@ struct Intersect<Compound, Compound> final
   Result operator() (const Compound &compound, const Compound &other) const
   {
     std::vector<std::shared_ptr<ArbiterRequirement>> requirements = compound._requirements;
+
+    requirements.reserve(requirements.size() + other._requirements.size());
     requirements.insert(requirements.end(), other._requirements.begin(), other._requirements.end());
+
     return std::make_unique<Compound>(std::move(requirements));
   }
 };
@@ -248,7 +251,10 @@ struct Intersect<Compound, Other> final
   Result operator() (const Compound &compound, const Other &other) const
   {
     std::vector<std::shared_ptr<ArbiterRequirement>> requirements = compound._requirements;
+
+    requirements.reserve(requirements.size() + 1);
     requirements.emplace_back(other.cloneRequirement());
+
     return std::make_unique<Compound>(std::move(requirements));
   }
 };

--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -294,7 +294,7 @@ DependencyGraph resolveDependencies (ArbiterResolver &resolver, const Dependency
           dependentsByTransitive[transitive._projectIdentifier] = dependency._project;
         }
 
-        collectedTransitives.insert(transitives.begin(), transitives.end());
+        collectedTransitives.insert(std::make_move_iterator(transitives.begin()), std::make_move_iterator(transitives.end()));
       }
 
       reset(choices);

--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -88,8 +88,6 @@ class DependencyGraph final
 
       if (dependent) {
         _edges[*dependent].insert(key);
-      } else {
-        _roots.insert(key);
       }
     }
 
@@ -164,8 +162,11 @@ class DependencyGraph final
     std::ostream &describe (std::ostream &os) const
     {
       os << "Roots:";
-      for (const NodeKey &key : _roots) {
-        os << "\n\t" << resolveNode(key);
+      for (const auto &pair : _nodeMap) {
+        const NodeKey &key = pair.first;
+        if (_edges.find(key) == _edges.end()) {
+          os << "\n\t" << resolveNode(key, pair.second);
+        }
       }
 
       os << "\n\nEdges";
@@ -227,7 +228,6 @@ class DependencyGraph final
 
     // TODO: Should these be unordered, with ordering instead applied in
     // resolvedGraph?
-    std::set<NodeKey> _roots;
     std::unordered_map<NodeKey, std::set<NodeKey>> _edges;
     std::unordered_map<NodeKey, NodeValue> _nodeMap;
 };

--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -100,6 +100,7 @@ class DependencyGraph final
 
       // Contains edges which still need to be added to the resolved graph.
       std::unordered_map<NodeKey, std::unordered_set<NodeKey>> remainingEdges;
+      remainingEdges.reserve(_edges.size());
 
       // Contains dependencies without any dependencies themselves.
       ArbiterResolvedDependencyGraph::DepthSet leaves;
@@ -240,6 +241,7 @@ DependencyGraph resolveDependencies (ArbiterResolver &resolver, const Dependency
   // This collection is reused when actually building the new dependency graph
   // below.
   std::unordered_map<ArbiterProjectIdentifier, std::unique_ptr<ArbiterRequirement>> requirementsByProject;
+  requirementsByProject.reserve(dependencySet.size());
 
   for (const ArbiterDependency &dependency : dependencySet) {
     requirementsByProject[dependency._projectIdentifier] = dependency.requirement().cloneRequirement();
@@ -316,6 +318,7 @@ DependencyGraph resolveDependencies (ArbiterResolver &resolver, const Dependency
       for (ArbiterResolvedDependency &dependency : choices) {
         std::vector<ArbiterDependency> transitives = resolver.fetchDependencies(dependency._project, dependency._version)._dependencies;
 
+        dependentsByTransitive.reserve(dependentsByTransitive.size() + transitives.size());
         for (const ArbiterDependency &transitive : transitives) {
           dependentsByTransitive[transitive._projectIdentifier] = dependency._project;
         }


### PR DESCRIPTION
_Depends on #69._

This is mostly optimization, but also partly semantics (e.g., sorting lists of dependencies by project identifier).